### PR TITLE
feat: re-direct links to etherscan

### DIFF
--- a/common-util/Details/ServiceState/4thStepDeployed/index.jsx
+++ b/common-util/Details/ServiceState/4thStepDeployed/index.jsx
@@ -3,7 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Table, Space } from 'antd/lib';
 import get from 'lodash/get';
-import { Address } from 'common-util/styles';
+import { AddressLink } from '@autonolas/frontend-library';
 import { setAgentInstancesAndOperators } from 'store/service/state/actions';
 import { getAgentInstanceAndOperator } from '../utils';
 
@@ -12,13 +12,13 @@ const columns = [
     title: 'Agent Instances',
     dataIndex: 'agentInstance',
     key: 'agentInstance',
-    render: (text) => <Address width={260}>{text}</Address>,
+    render: (text) => <AddressLink text={text} suffixCount={10} />,
   },
   {
     title: 'Operators',
     dataIndex: 'operatorAddress',
     key: 'operatorAddress',
-    render: (text) => <Address width={260}>{text}</Address>,
+    render: (text) => <AddressLink text={text} suffixCount={10} />,
   },
 ];
 

--- a/common-util/styles.jsx
+++ b/common-util/styles.jsx
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-export const Address = styled.div`
-  width: ${({ width }) => `${width || 120}px`};
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-`;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "^4.8.0",
-    "@autonolas/frontend-library": "0.3.18",
+    "@autonolas/frontend-library": "0.3.19",
     "@gnosis.pm/safe-contracts": "^1.3.0",
     "@wagmi/core": "^1.0.5",
     "@web3modal/ethereum": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -91,10 +91,10 @@
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.9.4.tgz#a483c54c1253656bb33babd464e3154a173e1577"
   integrity sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==
 
-"@autonolas/frontend-library@0.3.18":
-  version "0.3.18"
-  resolved "https://registry.yarnpkg.com/@autonolas/frontend-library/-/frontend-library-0.3.18.tgz#729d7e489f22a5f5b8dceac79f0b2a1f541a760e"
-  integrity sha512-v0TxfHZ2j/ZmFHczBNHTX4XlsgOX9NoXp/lcIadxtOzlkWzdkPyXLhRyDTuoJzI4ANSKNQezWkdjxYr0kpPvNw==
+"@autonolas/frontend-library@0.3.19":
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/@autonolas/frontend-library/-/frontend-library-0.3.19.tgz#a445471d08ec538de1b39fa3e361e42d2d1855c0"
+  integrity sha512-8JmbORvNb42nIjmevukYG0dAd5u7q7tilicxpkXseh9HMB0X2Ao7M28BJeLBU6t345LHzzcgMz67l0M4Cf2EnA==
   dependencies:
     "@ant-design/icons" "^4.8.0"
     "@storybook/builder-webpack5" "^7.0.15"


### PR DESCRIPTION
* On click - redirects to appropriate network's etherscan and truncates the address

<img width="714" alt="eee" src="https://github.com/valory-xyz/autonolas-registry-frontend/assets/22061815/ec38b323-37f4-4e99-831b-8851de437da6">
