### PR TITLE
fix: agent instances addresses error should not be enabled even If one instance is added

### DIFF
--- a/common-util/Details/ServiceState/ActiveRegistrationTable.jsx
+++ b/common-util/Details/ServiceState/ActiveRegistrationTable.jsx
@@ -83,8 +83,6 @@ const EditableCell = ({
     (agentInstance) => !!agentInstance?.agentAddresses,
   );
 
-  console.log({ agentInstances, hasAtleastOneAgentInstanceAddress });
-
   if (editable) {
     childNode = slots > 0 ? (
       <Form.Item
@@ -97,7 +95,8 @@ const EditableCell = ({
           },
           () => ({
             validator(_, value) {
-              // if no value is present, and there is atleast one agent instance address,
+              // even if one agent instance address is present,
+              // resolve if the value is empty
               if (hasAtleastOneAgentInstanceAddress && !value) {
                 return Promise.resolve();
               }

--- a/common-util/Details/ServiceState/index.jsx
+++ b/common-util/Details/ServiceState/index.jsx
@@ -149,7 +149,6 @@ export const ServiceState = ({
       .map((e) => e.trim());
 
     const ids = [];
-    console.log('dataSource', dataSource);
 
     // filter out instances that are empty
     const filteredDataSource = dataSource.filter(
@@ -171,9 +170,7 @@ export const ServiceState = ({
 
       return address;
     });
-
     const agentInstances = trimArray(instances || []);
-    console.log('agentInstances', agentInstances);
 
     try {
       // if not eth, check if the user has sufficient token balance


### PR DESCRIPTION
* Agent instances input should not throw an error even if one of the agent instances is present & the "Register Agent" button should be visible

https://github.com/valory-xyz/autonolas-registry-frontend/assets/22061815/fcc28114-f3a0-4bd2-b17b-c7ad561a719d

