### PR TITLE
fix: On "register agents" check if the agent instances is already registered

### DIFF
--- a/common-util/Details/ServiceState/index.jsx
+++ b/common-util/Details/ServiceState/index.jsx
@@ -18,6 +18,7 @@ import {
   checkIfEth,
   mintTokenRequest,
   checkAndApproveToken,
+  checkIfAgentInstancesAreValid,
 } from './utils';
 import StepActiveRegistration from './2StepActiveRegistration';
 import StepFinishedRegistration from './3rdStepFinishedRegistration';
@@ -183,14 +184,22 @@ export const ServiceState = ({
         });
       }
 
-      await onStep2RegisterAgents({
+      // check if the agent instances are valid
+      const isValid = await checkIfAgentInstancesAreValid({
         account,
-        serviceId: id,
-        agentIds: ids,
         agentInstances,
-        dataSource,
       });
-      await updateDetails();
+
+      if (isValid) {
+        await onStep2RegisterAgents({
+          account,
+          serviceId: id,
+          agentIds: ids,
+          agentInstances,
+          dataSource,
+        });
+        await updateDetails();
+      }
     } catch (e) {
       console.error(e);
     }


### PR DESCRIPTION
* If the account (wallet address) is already registered as agent instances

* If inputs are already registered as agent instances 

https://github.com/valory-xyz/autonolas-registry-frontend/assets/22061815/b04f2a3c-5180-416b-84c3-572f0d2f9cb8

